### PR TITLE
Drop winning challenge gen from Prover

### DIFF
--- a/storage/storage.go
+++ b/storage/storage.go
@@ -20,9 +20,7 @@ type Storage interface {
 }
 
 type Prover interface {
-	GenerateWinningPoStSectorChallenge(ctx context.Context, proofType abi.RegisteredProof, minerID abi.ActorID, randomness abi.PoStRandomness, eligibleSectorCount uint64) ([]uint64, error)
 	GenerateWinningPoSt(ctx context.Context, minerID abi.ActorID, sectorInfo []abi.SectorInfo, randomness abi.PoStRandomness) ([]abi.PoStProof, error)
-
 	GenerateWindowPoSt(ctx context.Context, minerID abi.ActorID, sectorInfo []abi.SectorInfo, randomness abi.PoStRandomness) ([]abi.PoStProof, error)
 }
 


### PR DESCRIPTION
`GenerateWinningPoStSectorChallenge` doesn't touch anything storage-related at all, it's also needed on the verifier side