### PR TITLE
Revert "windowed post generation now returns faulty sectors"

### DIFF
--- a/storage/storage.go
+++ b/storage/storage.go
@@ -22,7 +22,7 @@ type Storage interface {
 
 type Prover interface {
 	GenerateWinningPoSt(ctx context.Context, minerID abi.ActorID, sectorInfo []proof.SectorInfo, randomness abi.PoStRandomness) ([]proof.PoStProof, error)
-	GenerateWindowPoSt(ctx context.Context, minerID abi.ActorID, sectorInfo []proof.SectorInfo, randomness abi.PoStRandomness) (proof []proof.PoStProof, skipped []abi.SectorID, faulty []abi.SectorID, err error)
+	GenerateWindowPoSt(ctx context.Context, minerID abi.ActorID, sectorInfo []proof.SectorInfo, randomness abi.PoStRandomness) (proof []proof.PoStProof, skipped []abi.SectorID, err error)
 }
 
 type PreCommit1Out []byte


### PR DESCRIPTION
Reverts filecoin-project/specs-storage#12

It doesn't really make sense to treat skipped/faulty differently